### PR TITLE
Added image cache

### DIFF
--- a/src/Components/Comment/Comment.js
+++ b/src/Components/Comment/Comment.js
@@ -8,6 +8,7 @@ import {formatDate} from "../../Utility/Date";
 import ExpandableImage from "../Images/ExpandableImage";
 import axios from "axios";
 import React from "react";
+import {getCachedImageData} from "../../Utility/Cache";
 
 class Comment extends React.Component {
     state = {
@@ -17,11 +18,10 @@ class Comment extends React.Component {
 
     componentDidMount() {
         if(this.props.comment.postPhotoName != null) {
-            axios.get(process.env.REACT_APP_BACKEND_URL + '/posts/getPhoto?postId=' + this.props.comment.postId,
-                {headers: {"Authorization": `Bearer ${localStorage.getItem('token')}`}})
-                .then((response) => {
+            getCachedImageData(this.props.comment.postId)
+                .then((imageData) => {
                     this.setState({
-                        imageData: response.data
+                        imageData: imageData
                     });
                 })
         }

--- a/src/Components/Post/Post.js
+++ b/src/Components/Post/Post.js
@@ -7,6 +7,7 @@ import 'bootstrap/dist/js/bootstrap.min.js';
 import {formatDate} from "../../Utility/Date";
 import ExpandableImage from "../Images/ExpandableImage";
 import axios from "axios";
+import {getCachedImageData} from "../../Utility/Cache";
 
 class Post extends React.Component{
     state = {
@@ -16,11 +17,10 @@ class Post extends React.Component{
 
     componentDidMount() {
         if(this.props.post.postPhotoName != null) {
-            axios.get(process.env.REACT_APP_BACKEND_URL + '/posts/getPhoto?postId=' + this.props.post.postId,
-                {headers: {"Authorization": `Bearer ${localStorage.getItem('token')}`}})
-                .then((response) => {
+            getCachedImageData(this.props.post.postId)
+                .then((imageData) => {
                     this.setState({
-                        imageData: response.data
+                        imageData: imageData
                     });
                 })
         }

--- a/src/Utility/Cache.js
+++ b/src/Utility/Cache.js
@@ -1,0 +1,21 @@
+//Images have unique id's so they can be stored in localstorage and downloaded only once
+//Currently I made it use postid
+
+import axios from "axios";
+
+export async function getCachedImageData(postId) {
+    const key = "image/" + postId;
+
+    const fromStorage = localStorage.getItem(key);
+
+    //Image found in the storage
+    if(fromStorage!==null)return fromStorage;
+
+    //Image not found get it from backend
+    const response = await axios.get(process.env.REACT_APP_BACKEND_URL + '/posts/getPhoto?postId=' + postId,
+        {headers: {"Authorization": `Bearer ${localStorage.getItem('token')}`}});
+    const responseData = response.data;
+
+    localStorage.setItem(key, responseData);
+    return responseData;
+}


### PR DESCRIPTION
I found that loading images from the deployed server takes a long time. Images are unique to posts and don't change, so loading them multiple times is a waste. 
This simple change caches images in localStorage and makes the website work a lot faster decreasing number of expensive gets.
